### PR TITLE
style: 위키 목록 페이지 스타일 리팩토링

### DIFF
--- a/components/common/searchForm/styles.module.scss
+++ b/components/common/searchForm/styles.module.scss
@@ -15,6 +15,7 @@
   .input-wrapper {
     flex: 1;
     position: relative;
+    width: 100%;
 
     .search-icon {
       position: absolute;
@@ -24,26 +25,34 @@
     }
 
     input {
-      @include Size(100%, 40px);
+      @include Size(100%, 45px);
       @include Font(
-        $font-size-md,
-        $line-height-md,
-        $font-weight-md-regular,
+        $font-size-xl,
+        $line-height-5xl,
+        $font-weight-xl-medium,
         $color-grayscale-500
       );
       background-color: $color-grayscale-100;
       border: none;
-      border-radius: 8px;
-      padding: 7px 0 7px 58px;
+      border-radius: 10px;
+      padding: 12.5px 57px;
+      white-space: nowrap;
+      text-overflow: ellipsis;
+
+      &:focus {
+        outline: 2px solid $color-primary-green-200;
+      }
 
       &::placeholder {
         color: $color-grayscale-400;
+        font-weight: $font-weight-2xl-regular;
       }
     }
   }
 
   .search-button {
     @include Size(80px, 45px);
+    font-weight: $font-weight-2xl-medium !important;
   }
 }
 

--- a/components/wikilist/userWikiList/styles.module.scss
+++ b/components/wikilist/userWikiList/styles.module.scss
@@ -38,5 +38,10 @@
 @media screen and (max-width: $mobile-max-width) {
   .user-list-container {
     margin-top: 20px;
+
+    .user-list {
+      @include Flex(column, flex-start, flex-start);
+      row-gap: 8px;
+    }
   }
 }

--- a/components/wikilist/userWikiList/userWikiCard/index.tsx
+++ b/components/wikilist/userWikiList/userWikiCard/index.tsx
@@ -15,7 +15,6 @@ const UserWikiCard = ({ user }: UserCardProps) => {
       <Link className={styles['user-card-link']} href={`/wiki/${user.code}`}>
         <div className={styles['user-card']}>
           <div className={styles['user-profile-image-container']}>
-            {/* 프로필 이미지 */}
             {user.image ? (
               <Image
                 src={user.image}
@@ -34,7 +33,6 @@ const UserWikiCard = ({ user }: UserCardProps) => {
               />
             )}
           </div>
-          {/* 닉네임 및 정보 */}
           <div className={styles['user-info']}>
             <div className={styles['user-name']}>{user.name}</div>
             <div className={styles['user-details']}>

--- a/components/wikilist/userWikiList/userWikiCard/index.tsx
+++ b/components/wikilist/userWikiList/userWikiCard/index.tsx
@@ -12,37 +12,45 @@ interface UserCardProps {
 const UserWikiCard = ({ user }: UserCardProps) => {
   return (
     <div className={styles['user-card-container']}>
-      <Link className={styles['user-card']} href={`/wiki/${user.code}`}>
-        {user.image ? (
-          <img
-            src={user.image}
-            alt="프로필 이미지"
-            width={85}
-            height={85}
-            className={styles['profile-image']}
-          />
-        ) : (
-          <Image
-            src={DefaultProfileImg}
-            alt="프로필 이미지"
-            width={85}
-            height={85}
-            className={styles['profile-image']}
-          />
-        )}
-
-        <div className={styles['user-info']}>
-          <div className={styles['user-name']}>{user.name}</div>
-          <div className={styles['user-details']}>
-            <div>
-              {user.city}, {user.nationality}
+      <Link className={styles['user-card-link']} href={`/wiki/${user.code}`}>
+        <div className={styles['user-card']}>
+          <div className={styles['user-profile-image-container']}>
+            {/* 프로필 이미지 */}
+            {user.image ? (
+              <Image
+                src={user.image}
+                alt="프로필 이미지"
+                width={85}
+                height={85}
+                className={styles['profile-image']}
+              />
+            ) : (
+              <Image
+                src={DefaultProfileImg}
+                alt="프로필 이미지"
+                width={85}
+                height={85}
+                className={styles['profile-image']}
+              />
+            )}
+          </div>
+          {/* 닉네임 및 정보 */}
+          <div className={styles['user-info']}>
+            <div className={styles['user-name']}>{user.name}</div>
+            <div className={styles['user-details']}>
+              <div className={styles['user-address']}>
+                {user.city}, {user.nationality}
+              </div>
+              <div className={styles['user-job']}>{user.job}</div>
             </div>
-            <div>{user.job}</div>
           </div>
         </div>
       </Link>
       <div className={styles['user-link-container']}>
-        <UserWikiLink url={`https://www.wikied.kr/wiki/${user.code}`} />
+        <UserWikiLink
+          url={`https://www.wikied.kr/wiki/${user.code}`}
+          user={user}
+        />
       </div>
     </div>
   );

--- a/components/wikilist/userWikiList/userWikiCard/styles.module.scss
+++ b/components/wikilist/userWikiList/userWikiCard/styles.module.scss
@@ -12,6 +12,10 @@
   background-color: $color-grayscale-50;
   box-shadow: 0px 4px 20px 0px rgba(0, 0, 0, 0.08);
   cursor: pointer;
+
+  &:hover {
+    background-color: $color-grayscale-100;
+  }
 }
 
 .user-card-link {
@@ -25,10 +29,6 @@
   @include Flex(row, flex-start, flex-start);
   gap: 32px;
   text-decoration: none;
-
-  &:hover {
-    background-color: $color-grayscale-100;
-  }
 }
 
 .user-profile-image-container {

--- a/components/wikilist/userWikiList/userWikiCard/styles.module.scss
+++ b/components/wikilist/userWikiList/userWikiCard/styles.module.scss
@@ -1,23 +1,40 @@
 @import '@/styles/index.scss';
 
 .user-card-container {
-  width: 100%;
   position: relative;
-}
-
-.user-card {
-  @include Flex(row, flex-start, flex-start);
+  width: 100%;
+  height: 142px;
+  display: flex;
+  justify-content: space-between;
   padding: 24px 36px;
   border: 1px solid $color-grayscale-100;
   border-radius: 10px;
   background-color: $color-grayscale-50;
   box-shadow: 0px 4px 20px 0px rgba(0, 0, 0, 0.08);
   cursor: pointer;
+}
+
+.user-card-link {
+  display: block;
+  width: 100%;
+  height: 100%;
+  text-decoration: none;
+}
+
+.user-card {
+  @include Flex(row, flex-start, flex-start);
+  gap: 32px;
   text-decoration: none;
 
   &:hover {
     background-color: $color-grayscale-100;
   }
+}
+
+.user-profile-image-container {
+  width: 85px;
+  height: 85px;
+  aspect-ratio: 1 / 1;
 }
 
 .profile-image {
@@ -27,7 +44,9 @@
 
 .user-info {
   @include Flex(column, flex-start, flex-start);
-  margin-left: 32px;
+  flex: 1 1 auto;
+  min-width: 0;
+  gap: 14px;
 }
 
 .user-name {
@@ -37,6 +56,7 @@
     $font-weight-2xl-semibold,
     $color-grayscale-500
   );
+  min-width: 0;
   border: none;
 }
 
@@ -47,7 +67,19 @@
     $font-weight-md-regular,
     $color-grayscale-400
   );
-  margin-top: 14px;
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+  width: 100%;
+}
+
+.user-name,
+.user-address,
+.user-job {
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+  width: 100%;
 }
 
 .user-link-container {
@@ -57,8 +89,17 @@
 }
 
 @media screen and (max-width: $mobile-max-width) {
-  .user-card {
+  .user-card-container {
     padding: 21px 25px;
+    height: 150px;
+  }
+
+  .user-card {
+    gap: 20px;
+  }
+
+  .user-info {
+    gap: 10px;
   }
 
   .user-name {
@@ -80,19 +121,15 @@
     );
   }
 
-  .profile-image {
-    margin-bottom: 16px;
+  .user-profile-image-container {
     width: 60px;
     height: 60px;
+    aspect-ratio: 1 / 1;
   }
 
-  .user-info {
-    margin-left: 20px;
-  }
-
-  .user-details {
-    margin-top: 10px;
-    margin-bottom: 40px;
+  .profile-image {
+    width: 60px;
+    height: 60px;
   }
 
   .user-link-container {

--- a/components/wikilist/userWikiList/userWikiCard/styles.module.scss
+++ b/components/wikilist/userWikiList/userWikiCard/styles.module.scss
@@ -136,7 +136,7 @@
     right: auto;
     left: 105px;
     bottom: 21px;
-    max-width: calc(100% - 125px);
+    max-width: calc(100% - 130px);
     overflow: hidden;
     white-space: nowrap;
   }

--- a/components/wikilist/userWikiList/userWikiCard/userWikiLink/index.tsx
+++ b/components/wikilist/userWikiList/userWikiCard/userWikiLink/index.tsx
@@ -3,16 +3,19 @@ import styles from './styles.module.scss';
 import LinkIcon from '@/assets/icons/ic_link.svg';
 import SnackBar from '@/components/common/snackbar';
 import Image from 'next/image';
+import { ProfileSummary } from '@/types/wiki';
 
 interface UserLinkProps {
   url: string;
+  user: ProfileSummary;
 }
 
-const UserWikiLink = ({ url }: UserLinkProps) => {
+const UserWikiLink = ({ url, user }: UserLinkProps) => {
   const [showSnackBar, setShowSnackBar] = useState(false);
   const [snackBarSize, setSnackBarSize] = useState<'small' | 'large'>('large');
 
-  const copyToClipboard = () => {
+  const copyToClipboard = (e: React.MouseEvent) => {
+    e.stopPropagation();
     navigator.clipboard
       .writeText(url)
       .then(() => {
@@ -60,7 +63,9 @@ const UserWikiLink = ({ url }: UserLinkProps) => {
       )}
       <div className={styles['link-container']} onClick={copyToClipboard}>
         <Image src={LinkIcon} alt="링크" width={20} height={20} />
-        <span className={styles['link-text']}>{url}</span>
+        <span className={styles['link-text']}>
+          {'https://www.wikied.kr/' + user.id}
+        </span>
       </div>
     </div>
   );

--- a/components/wikilist/userWikiList/userWikiCard/userWikiLink/styles.module.scss
+++ b/components/wikilist/userWikiList/userWikiCard/userWikiLink/styles.module.scss
@@ -21,6 +21,11 @@
     $color-primary-green-200
   );
   text-decoration: none;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  display: block;
+  width: 100%;
 
   &:hover {
     text-decoration: underline;


### PR DESCRIPTION
## PR 유형
어떤 변경 사항이 있나요?
- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [x] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

<br/>

## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).

<br/>

## ✅ 작업 내용
#### 검색바
  - input
     - height, font, placeholder, padding, border-radius 변경
       <img width="485" height="82" alt="image" src="https://github.com/user-attachments/assets/420f4294-57b0-472b-a87b-ba8160ae5134" />
     - 포커스 시 `outline` 색상 지정
       <img width="486" height="80" alt="image" src="https://github.com/user-attachments/assets/38487c2b-ddd0-4d7e-9b13-782d0483edea" />
  - 검색 버튼
    - font-weight 600 → 500으로 수정

<br/>

#### 위키 카드
  - 모바일 사이즈에서 위키 카드의 간격 조정
  - 화면 크기 축소 시 요소 간 간격 조정, 프로필 이미지 비율(1:1) 유지, 위키 카드 내 텍스트 `ellipsis` 적용
    <img width="287" height="227" alt="image" src="https://github.com/user-attachments/assets/a36a171f-438f-4471-a166-eb94514829ef" />
  - 화면 표시용 위키 링크의 path 변경(code → 게시글 ID), 기능상 동작은 유지
    <img width="905" height="222" alt="image" src="https://github.com/user-attachments/assets/5e2411e3-8331-42b7-b913-1dfbb03bc2f4" />
  - hover 시 배경색 변경 범위를 프로필 영역 → 위키 카드 전체로 확장
    <img width="738" height="970" alt="image" src="https://github.com/user-attachments/assets/e6402efa-37ab-49bd-89a4-acbaca0e2764" />

<br/>

## 📸 스크린샷
- PC, Tablet 사이즈
  <img width="1920" height="1286" alt="image" src="https://github.com/user-attachments/assets/e23af266-68ee-443e-9fb0-e1e442420222" />
- Mobile 사이즈
  <img width="959" height="1794" alt="image" src="https://github.com/user-attachments/assets/6c0f38b4-a4d4-4c8c-9f79-fda2a9dd1173" />
