### PR TITLE
fix: 헤더 모바일 사이즈 스타일 및 메뉴 토글 동작 개선

### DIFF
--- a/components/common/header/components/deskToggle/index.tsx
+++ b/components/common/header/components/deskToggle/index.tsx
@@ -1,15 +1,10 @@
-
 import { useEffect, useRef } from 'react';
 import styles from '@/components/common/header/components/deskToggle/styles.module.scss';
 import useWikiNavigation from '@/hooks/useCode/useCode';
 import { useAuth } from '@/contexts/AuthProvider';
 import { useRouter } from 'next/router';
 
-type MenuProps = {
-  handleMenuClose: () => void;
-};
-
-const DeskMenu = ({ handleMenuClose }: MenuProps) => {
+const DeskMenu = () => {
   const menuRef = useRef<HTMLDivElement>(null);
   const { logout } = useAuth();
   const { handleNavigationWiki } = useWikiNavigation();
@@ -17,22 +12,7 @@ const DeskMenu = ({ handleMenuClose }: MenuProps) => {
 
   const handleLogoutClick = () => {
     logout();
-    handleMenuClose();
   };
-
-  useEffect(() => {
-    const handleClickOutside = (event: MouseEvent) => {
-      if (menuRef.current && !menuRef.current.contains(event.target as Node)) {
-        handleMenuClose();
-      }
-    };
-
-    document.addEventListener('mousedown', handleClickOutside);
-
-    return () => {
-      document.removeEventListener('mousedown', handleClickOutside);
-    };
-  }, [handleMenuClose]);
 
   return (
     <div className={styles['container']} ref={menuRef}>
@@ -40,7 +20,6 @@ const DeskMenu = ({ handleMenuClose }: MenuProps) => {
         className={styles['menu-list']}
         onClick={() => {
           router.push('/mypage');
-          handleMenuClose();
         }}
       >
         계정 설정
@@ -49,7 +28,6 @@ const DeskMenu = ({ handleMenuClose }: MenuProps) => {
         className={styles['menu-list']}
         onClick={() => {
           handleNavigationWiki();
-          handleMenuClose();
         }}
       >
         내 위키

--- a/components/common/header/components/list/styles.module.scss
+++ b/components/common/header/components/list/styles.module.scss
@@ -21,11 +21,7 @@
 
 @media screen and (max-width: $mobile-max-width) {
   .item-list {
-    .wiki {
-      display: none;
-    }
-
-    .boards {
+    .link {
       display: none;
     }
   }

--- a/components/common/header/components/mobileToggle/index.tsx
+++ b/components/common/header/components/mobileToggle/index.tsx
@@ -4,11 +4,7 @@ import { useRouter } from 'next/router';
 import { useAuth } from '@/contexts/AuthProvider';
 import EditNotification from '@/components/common/modal/components/editNotification';
 
-type MenuProps = {
-  handleMenuClose: () => void;
-};
-
-const MobileMenu = ({ handleMenuClose }: MenuProps) => {
+const MobileMenu = () => {
   const router = useRouter();
   const menuRef = useRef<HTMLDivElement>(null);
   const [isModalOpen, setIsModalOpen] = useState(false);
@@ -16,30 +12,13 @@ const MobileMenu = ({ handleMenuClose }: MenuProps) => {
 
   const handleNavigation = (path: string) => {
     router.push(path);
-    handleMenuClose();
   };
 
   const { logout } = useAuth();
 
   const handleLogoutClick = () => {
     logout();
-    handleMenuClose();
   };
-
-  // Click outside the menu to close it
-  useEffect(() => {
-    const handleClickOutside = (event: MouseEvent) => {
-      if (menuRef.current && !menuRef.current.contains(event.target as Node)) {
-        handleMenuClose();
-      }
-    };
-
-    document.addEventListener('mousedown', handleClickOutside);
-
-    return () => {
-      document.removeEventListener('mousedown', handleClickOutside);
-    };
-  }, [handleMenuClose]);
 
   const toggleModal = () => {
     setIsModalOpen((prev) => !prev);

--- a/components/common/header/components/userProfile/index.tsx
+++ b/components/common/header/components/userProfile/index.tsx
@@ -9,8 +9,8 @@ import { getProfileByCode } from '@/services/api/profile';
 import { useAuth } from '@/contexts/AuthProvider';
 
 type UserProfileProps = {
-  mobileMenu: () => void;
-  deskMenu: () => void;
+  mobileMenu: (e: React.MouseEvent<HTMLButtonElement>) => void;
+  deskMenu: (e: React.MouseEvent<HTMLButtonElement>) => void;
 };
 
 const UserProfile = ({ mobileMenu, deskMenu }: UserProfileProps) => {
@@ -63,7 +63,7 @@ const UserProfile = ({ mobileMenu, deskMenu }: UserProfileProps) => {
         <Image src={alarm} alt="알림" width={32} height={32} />
       </button>
       {profileImage ? (
-        <button className={styles['profile-user']} onClick={deskMenu}>
+        <button className={styles['profile-user']} onClick={(e) => deskMenu(e)}>
           <img
             className={styles['profile-user-img']}
             src={profileImage}
@@ -73,7 +73,10 @@ const UserProfile = ({ mobileMenu, deskMenu }: UserProfileProps) => {
           />
         </button>
       ) : (
-        <button className={styles['profile-default']} onClick={deskMenu}>
+        <button
+          className={styles['profile-default']}
+          onClick={(e) => deskMenu(e)}
+        >
           <Image
             className={styles['profile-default-img']}
             src={profile}
@@ -83,7 +86,7 @@ const UserProfile = ({ mobileMenu, deskMenu }: UserProfileProps) => {
           />
         </button>
       )}
-      <button className={styles['menu']} onClick={mobileMenu}>
+      <button className={styles['menu']} onClick={(e) => mobileMenu(e)}>
         <Image src={menu} alt="메뉴" width={24} height={24} />
       </button>
       {isModalOpen && (

--- a/components/common/header/index.tsx
+++ b/components/common/header/index.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useState, useEffect, useRef } from 'react';
 import styles from '@/components/common/header/styles.module.scss';
 import MobileMenu from './components/mobileToggle';
 import Logo from './components/logo';
@@ -12,23 +12,33 @@ const Header = () => {
   const [isMobileMenu, setIsMobileMenu] = useState(false);
   const [isDeskMenuOpen, setIsDeskMenuOpen] = useState(false);
   const { isLoggedIn } = useAuth();
+  const headerRef = useRef<HTMLElement>(null);
 
-  const mobileMenu = () => {
+  const mobileMenu = (e: React.MouseEvent<HTMLButtonElement>) => {
+    e.stopPropagation();
     setIsMobileMenu((prev) => !prev);
   };
 
-  const deskMenu = () => {
+  const deskMenu = (e: React.MouseEvent<HTMLButtonElement>) => {
+    e.stopPropagation();
     setIsDeskMenuOpen((prev) => !prev);
-    console.log(isDeskMenuOpen);
   };
 
-  const handleMenuClose = () => {
-    setIsMobileMenu(false);
-    setIsDeskMenuOpen(false);
-  };
+  useEffect(() => {
+    const handleClickOutside = (e: MouseEvent) => {
+      if (headerRef.current && !headerRef.current.contains(e.target as Node)) {
+        setIsMobileMenu(false);
+        setIsDeskMenuOpen(false);
+      }
+    };
+    document.addEventListener('mousedown', handleClickOutside);
+    return () => {
+      document.removeEventListener('mousedown', handleClickOutside);
+    };
+  }, []);
 
   return (
-    <header className={styles['container']}>
+    <header className={styles['container']} ref={headerRef}>
       <div className={styles['logo-item-wrapper']}>
         <Logo />
         <List />
@@ -40,8 +50,8 @@ const Header = () => {
           <GuestProfile />
         )}
       </div>
-      {isMobileMenu && <MobileMenu handleMenuClose={handleMenuClose} />}
-      {isDeskMenuOpen && <DeskMenu handleMenuClose={handleMenuClose} />}
+      {isMobileMenu && <MobileMenu />}
+      {isDeskMenuOpen && <DeskMenu />}
     </header>
   );
 };


### PR DESCRIPTION
## PR 유형
어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [x] 버그 수정
- [x] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

<br/>

## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).

<br/>

## ✅ 작업 내용
- 모바일 사이즈에서 위키목록, 자유게시판 숨김 처리
  <img width="783" height="526" alt="image" src="https://github.com/user-attachments/assets/49c871be-bcd6-4a91-9274-cf17b15b8222" />
- 프로필 버튼 클릭 시 메뉴 토글 동작 정상화