### PR TITLE
fix: 위키페이지에서 profile이 null일 때 TypeError 해결

### DIFF
--- a/pages/wiki/[code]/index.tsx
+++ b/pages/wiki/[code]/index.tsx
@@ -57,7 +57,7 @@ const Wiki = (props: WikiProps) => {
       const response = await getProfileByCode(code);
       const data = response.data;
       setProfile(data);
-      setSectionsData(profile.content || []);
+      setSectionsData(profile?.content || []);
     } catch (err) {
       console.log(err);
     }


### PR DESCRIPTION
## PR 유형
어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [x] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

<br/>

## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).

<br/>

## ✅ 작업 내용
- 위키페이지에서 profile이 null일 때 TypeError 해결
  ```
  TypeError: Cannot read properties of null (reading 'content')
      at eval (index.tsx:60:31)
      at async fetchData (index.tsx:92:9)
  ```